### PR TITLE
Don't require the output of stats to be exactly 3 lines

### DIFF
--- a/main.py
+++ b/main.py
@@ -114,7 +114,9 @@ async def handler(request):
                     pass
 
             # parse stats
-            names, values, _ = [a.split() for a in stats.splitlines()]
+            lines = stats.splitlines()
+            names = lines[0].split()
+            values = lines[1].split()
 
             # Replace stats
             for i, name in enumerate(names):


### PR DESCRIPTION
[14/04/2019 17:47] ERROR test handler 132: not enough values to unpack (expected 3, got 2)
Traceback (most recent call last):
  File "main.py", line 117, in handler
    names, values, _ = [a.split() for a in stats.splitlines()]
ValueError: not enough values to unpack (expected 3, got 2)


Looks like stats does not always return 3 lines. I've modified the code to look at any amount of lines and then deal with the first two.